### PR TITLE
Quote the phrase before compiling in a pattern

### DIFF
--- a/criteria2query/src/main/java/edu/columbia/dbmi/ohdsims/tool/NegReTool.java
+++ b/criteria2query/src/main/java/edu/columbia/dbmi/ohdsims/tool/NegReTool.java
@@ -140,7 +140,7 @@ public class NegReTool {
 		// Tag the phrases we want to detect for negation.
 		// Should happen before rule detection.
 		String phrase = phraseString;
-		Pattern pph = Pattern.compile(phrase.trim(), Pattern.CASE_INSENSITIVE);
+		Pattern pph = Pattern.compile(Pattern.quote(phrase.trim()), Pattern.CASE_INSENSITIVE);
 		Matcher mph = pph.matcher(sentence);
 
 		while (mph.find() == true) {


### PR DESCRIPTION
Special regex characters in the phrase can trigger the failure of pattern compilation